### PR TITLE
Consolidate some unique deaths

### DIFF
--- a/lib/junethack/normalize_death.rb
+++ b/lib/junethack/normalize_death.rb
@@ -47,16 +47,16 @@ class Game
     # poisoned by a rotted {monster} corpse -> poisoned by a rotted corpse
     death = death.gsub(/poisoned by a rotted .* corpse/, "poisoned by a rotted corpse")
 
-    # wrath of dieties
-    death = death.gsub(/wrath of .+/, "wrath of a diety")
+    # wrath of deities
+    death = death.gsub(/wrath of .+/, "wrath of a deity")
 
-    # consolidate priest & priestess gender; strip the diety.
+    # consolidate priest & priestess gender; strip the deity.
     death = death.gsub(/priest(ess)?/, "priest(ess)")
-    death = death.gsub(/priest\(ess\) of .+/, "priest(ess) of a diety")
+    death = death.gsub(/priest\(ess\) of .+/, "priest(ess) of a deity")
 
-    # killed by the {minion} of {diety} -> 'killed by the minion of a diety'.
+    # killed by the {minion} of {deity} -> 'killed by the minion of a deity'.
     # minion list is from vanilla...
-    death = death.gsub(/\w+ elemental|Aleax|couatl|Angel|\w+ demon|\w+ devil|(suc|in)cubus|balrog|pit fiend|nalfeshnee|hezrou|vrock|marilith|erinyes) of .+/, "minion of a diety")
+    death = death.gsub(/\w+ elemental|Aleax|couatl|Angel|\w+ demon|\w+ devil|(suc|in)cubus|balrog|pit fiend|nalfeshnee|hezrou|vrock|marilith|erinyes) of .+/, "minion of a deity")
 
     death
   end

--- a/lib/junethack/normalize_death.rb
+++ b/lib/junethack/normalize_death.rb
@@ -36,7 +36,13 @@ class Game
     end
 
     # killed by a falling {foo} -> killed by a falling object (except for rock from a rock trap).
-    deaths = death.gsub(/killed by a falling (?!rock).*$/, "killed by a falling object")
+    death = death.gsub(/killed by a falling (?!rock).*$/, "killed by a falling object")
+
+    # consolidate shopkeepers
+    death = death.gsub(/M[rs]\. [A-Z].*, the shopkeeper/, "a shopkeeper")
+
+    # consolidate ghosts
+    death = death.gsub(/ ghost of .*/, " ghost")
 
     death
   end

--- a/lib/junethack/normalize_death.rb
+++ b/lib/junethack/normalize_death.rb
@@ -2,7 +2,7 @@ require 'pry'
 class Game
   def normalize_death
     # no need to be grammatical correct
-    death = self.death.gsub /^killey by an /, "killed by a "
+    death = self.death.gsub /^killed by an /, "killed by a "
 
     death = death.gsub /, while .*/, ""
 
@@ -34,6 +34,10 @@ class Game
     else
       death = death.gsub(/killed by kicking .*/, "killed by kicking something")
     end
+
+    # killed by a falling {foo} -> killed by a falling object (except for rock from a rock trap).
+    deaths = death.gsub(/killed by a falling (?!rock).*$/, "killed by a falling object")
+
     death
   end
 end

--- a/lib/junethack/normalize_death.rb
+++ b/lib/junethack/normalize_death.rb
@@ -47,6 +47,17 @@ class Game
     # poisoned by a rotted {monster} corpse -> poisoned by a rotted corpse
     death = death.gsub(/poisoned by a rotted .* corpse/, "poisoned by a rotted corpse")
 
+    # wrath of dieties
+    death = death.gsub(/wrath of .+/, "wrath of a diety")
+
+    # consolidate priest & priestess gender; strip the diety.
+    death = death.gsub(/priest(ess)?/, "priest(ess)")
+    death = death.gsub(/priest\(ess\) of .+/, "priest(ess) of a diety")
+
+    # killed by the {minion} of {diety} -> 'killed by the minion of a diety'.
+    # minion list is from vanilla...
+    death = death.gsub(/\w+ elemental|Aleax|couatl|Angel|\w+ demon|\w+ devil|(suc|in)cubus|balrog|pit fiend|nalfeshnee|hezrou|vrock|marilith|erinyes) of .+/, "minion of a diety")
+
     death
   end
 end

--- a/lib/junethack/normalize_death.rb
+++ b/lib/junethack/normalize_death.rb
@@ -36,13 +36,16 @@ class Game
     end
 
     # killed by a falling {foo} -> killed by a falling object (except for rock from a rock trap).
-    death = death.gsub(/killed by a falling (?!rock).*$/, "killed by a falling object")
+    death = death.gsub(/killed by a falling (?!rock).+$/, "killed by a falling object")
 
     # consolidate shopkeepers
     death = death.gsub(/M[rs]\. [A-Z].*, the shopkeeper/, "a shopkeeper")
 
     # consolidate ghosts
-    death = death.gsub(/ ghost of .*/, " ghost")
+    death = death.gsub(/ ghost of .+/, " ghost")
+
+    # poisoned by a rotted {monster} corpse -> poisoned by a rotted corpse
+    death = death.gsub(/poisoned by a rotted .* corpse/, "poisoned by a rotted corpse")
 
     death
   end

--- a/lib/junethack/normalize_death.rb
+++ b/lib/junethack/normalize_death.rb
@@ -39,10 +39,10 @@ class Game
     death = death.gsub(/killed by a falling (?!rock).+$/, "killed by a falling object")
 
     # consolidate shopkeepers
-    death = death.gsub(/M[rs]\. [A-Z].*, the shopkeeper/, "a shopkeeper")
+    death = death.gsub(/ (an? )?M[rs]\. [A-Z].*, the shopkeeper/, " a shopkeeper")
 
     # consolidate ghosts
-    death = death.gsub(/ ghost of .+/, " ghost")
+    death = death.gsub(/ (an?|the) ghost of .+/, " a ghost")
 
     # poisoned by a rotted {monster} corpse -> poisoned by a rotted corpse
     death = death.gsub(/poisoned by a rotted .* corpse/, "poisoned by a rotted corpse")
@@ -56,7 +56,7 @@ class Game
 
     # killed by the {minion} of {deity} -> 'killed by the minion of a deity'.
     # minion list is from vanilla...
-    death = death.gsub(/\w+ elemental|Aleax|couatl|Angel|\w+ demon|\w+ devil|(suc|in)cubus|balrog|pit fiend|nalfeshnee|hezrou|vrock|marilith|erinyes) of .+/, "minion of a deity")
+    death = death.gsub(/(\w+ elemental|Aleax|couatl|Angel|\w+ demon|\w+ devil|(suc|in)cubus|balrog|pit fiend|nalfeshnee|hezrou|vrock|marilith|erinyes) of .+/, "minion of a deity")
 
     death
   end


### PR DESCRIPTION
In the interest of avoiding tedious death scumming to instead focus on more different "types" of deaths.

1. 'killed by an' -> 'killed by a' (it's already in the code but was typo'd "killey").
2. killed by a falling {objectname} -> killed by a falling object. This happens in grunthack. Exception: killed by a falling rock (which happens from a rock trap and vanilla preserves it).
3. killed by Mr/Ms {foo}, the shopkeeper -> killed by a shopkeeper.
4. killed by the ghost of {playername} -> killed by a ghost.
5. poisoned by a rotted {monstername} corpse -> poisoned by a rotted corpse
6. wrath of {deityname} -> wrath of a deity.
7. priest/priestess of {deityname} -> priest(ess) of a deity (two separate lines in the code since you can be killed by a priest/ess not of a deity, I think. Well, last year someone was anyway).
8. killed by the {minion} of {deityname} -> killed by the minion of a deity. The minions are hard-coded according to vanilla nethack minions, so if other variants add minions they won't be caught. The other option is to hard-code the (many, many) deity names for all the variants; or to do something like '.* of .*', which is too general and captures many other deaths ('scroll of genocide', ...).

I have a list of differences between junethack 2014's deaths and this new version here:
https://drive.google.com/file/d/0B89NhOyxbd9PSXJXdGNOaVpINTA/view?usp=sharing

the first column is the junethack 2014 unique death; the latter is the new death under this patch.