### PR TITLE
Fix bugs caused by update to dNetHack trophies

### DIFF
--- a/lib/junethack/trophy_calculations.rb
+++ b/lib/junethack/trophy_calculations.rb
@@ -79,17 +79,17 @@ end
 # dNetHack
 def dnethack_tour?(user)
     anz = repository.adapter.select("select count(distinct race), count(distinct role) from games where user_id = ? and version == 'DNH' and turns >= 1000 and (race in ('Inc','Clo','Dro','Hlf') or role in ('Nob','Pir','Bin','Brd', 'Ana', 'Con'));", user)[0]
-    return (anz[0]+anz[1]) == 8
+    return (anz[0]+anz[1]) == 10
 end
 
 def dnethack_king?(user)
     anz = repository.adapter.select("select count(distinct race), count(distinct role) from games where user_id = ? and version == 'DNH' and ascended='t' and (race in ('Inc','Clo','Dro','Hlf') or role in ('Nob','Pir','Bin','Brd', 'Ana', 'Con'));", user)[0]
-    return (anz[0]+anz[1]) == 8
+    return (anz[0]+anz[1]) == 10
 end
 
 def dnethack_prince?(user)
     anz = repository.adapter.select("select count(distinct race), count(distinct role) from games where user_id = ? and version == 'DNH' and ascended='t' and (race in ('Inc','Clo','Dro','Hlf') or role in ('Nob','Pir','Bin','Brd', 'Ana', 'Con'));", user)[0]
-    return (anz[0]+anz[1]) >= 4
+    return (anz[0]+anz[1]) >= 5
 end
 
 def update_scores(game)


### PR DESCRIPTION
f01e1e38037a1ab997224283e2950dc596a63a9d added Anachronaut and Convict roles to dNetHack trophies, but failed to update the conditions, causing some bizarre bugs (you should play exactly 8 combinations of new roles/races to get dNetHack Tour, for example; any more or less, and no prize for you.)