### PR TITLE
Consolidate more ghost death messages

### DIFF
--- a/lib/junethack/normalize_death.rb
+++ b/lib/junethack/normalize_death.rb
@@ -50,7 +50,7 @@ class Game
     end
 
     # consolidate ghosts
-    death = death.gsub(/ (an?|the) ghost of .+/, " a ghost")
+    death = death.gsub(/(an?|the?) ghost of .+/, " a ghost")
 
     # poisoned by a rotted {monster} corpse -> poisoned by a rotted corpse
     death = death.gsub(/poisoned by a rotted .* corpse/, "poisoned by a rotted corpse")


### PR DESCRIPTION
This should catch the following ghost deaths that were not caught in JNH previously:

killed by ghost of Andries
killed by ghost of Bert
killed by ghost of Emile
killed by ghost of Frans
killed by ghost of Jiro
killed by ghost of Karnov
killed by ghost of Katrice
killed by ghost of Kenny
killed by ghost of Peter
killed by ghost of Nick Danger
killed by ghost of noty
killed by ghost of D
killed by ghost of DUCKSCUM
killed by ghost of David
killed by ghost of FIQ
killed by ghost of Glenn Wichman
killed by ghost of Kenneth Arnold
killed by ghost of Michael Toy
killed by ghost of Tangles
killed by ghost of r e k t
killed by ghost of scURSCum
killed by ghost of scurscum