### PR TITLE
Count "with the amulet" deaths as unique

### DIFF
--- a/lib/junethack/normalize_death.rb
+++ b/lib/junethack/normalize_death.rb
@@ -22,7 +22,6 @@ class Game
 
     death = death.gsub(/ (called|named) .*/, "")
 
-    death = death.gsub(/ \(with the Amulet\)$/, "")
     # no lookbehind in 1.8.7
     death = death.gsub(/choked on .*/, "choked on something")
 


### PR DESCRIPTION
It represents the loss of significant time investment, isn't scummable, and is a quite *unique* experience!  

Throw these unlucky players a bone in the form of a unique death.