### PR TITLE
Add the ability to write clan "descriptions".

### DIFF
--- a/lib/junethack/models/clan.rb
+++ b/lib/junethack/models/clan.rb
@@ -7,6 +7,7 @@ class Clan
   property :name,     String, :key => true, :length => 1...30
   property :invitations,     Json, :default => []
   property :gravatar, String, length: 32
+  property :description, String, length: 500, :default => ""
 
   validates_format_of :name, :with => /^\w*$/, :message => "Clan name may only contain a-z, A-Z and 0-9"
   def get_invitation_response invitation

--- a/lib/junethack/sinatra_server.rb
+++ b/lib/junethack/sinatra_server.rb
@@ -319,6 +319,20 @@ get "/clan/:name" do
     end
 end
 
+post '/clan_description/:name' do
+  $db_access.synchronize {
+    @clan = Clan.get(params[:name])
+    redirect '/' if @clan.nil?
+    redirect '/' if @user != @clan.get_admin
+
+    if params[:description]
+      @clan.description = params[:description]
+      @clan.save!
+    end
+  }
+  redirect "/clan/#{@clan.name}"
+end
+
 post '/clan_banner/:name' do
   $db_access.synchronize {
     @clan = Clan.get(params[:name])

--- a/public/style.css
+++ b/public/style.css
@@ -735,6 +735,16 @@ th.competition_placing {
     background-color: #dadada;
     text-decoration: none;
 }
+#clan_description {
+    border-bottom: 3px double #bbb;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+}
+#clan_description_input form {
+    border-bottom: 3px double #bbb;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+}
 /**************************
 **                       **
 ** Display trophy images **

--- a/views/clan.haml
+++ b/views/clan.haml
@@ -28,8 +28,21 @@
       #clan_banner
         %img{src: @clan.gravatar_link}
 
+        #clan_description
+          :escaped
+            #{ p @clan.description }
+
         - if !@logged_in
           - if @user.login == @clan.get_admin.login
+            %p
+              Type a description for your clan (maximum length 500 characters).
+            #clan_description_input
+              %form{action: "/clan_description/#{@clan.name}", method: :post}
+                %fieldset
+                  .description
+                    %input{name: :description, type: :text, value: "", maxlength: 500}/
+                  .buttons
+                    %input{name: :submit, type: :submit, value: "set description"}/
             %p
               Enter the email address of a
               %a{href: 'https://en.gravatar.com/'}Gravatar


### PR DESCRIPTION
This PR adds clan descriptions where clan admins can write their war cries or whatever.

* Added new property to clan DB model, "description", maximum 500 characters.
* Modified clan view to show the description, and if you are an admin of the clan, a form to update the description.
* Some CSS to make it look nice.

I did this to test it:

1) That adding HTML code to the description like `<p>test</p>` is
   escaped properly.
2) SQL injections don't work.
3) The page looks okay on Firefox when both logged in and logged out.
4) Adding empty description does not crash anything.
5) Looked at the page in Firefox, Chrome and Safari to make sure it
   isn't broken on any of these browsers.

# Safari:

![Screen Shot 2021-05-29 at 11 12 53 AM](https://user-images.githubusercontent.com/833719/120080754-37807380-c06f-11eb-9610-5b0b74c22d75.png)

![Screen Shot 2021-05-29 at 11 13 02 AM](https://user-images.githubusercontent.com/833719/120080760-3e0eeb00-c06f-11eb-8cce-a9507cea1314.png)

# Chrome:

![Screen Shot 2021-05-29 at 11 12 21 AM](https://user-images.githubusercontent.com/833719/120080769-42d39f00-c06f-11eb-9ee0-4044e25ea1b4.png)

![Screen Shot 2021-05-29 at 11 12 31 AM](https://user-images.githubusercontent.com/833719/120080772-4404cc00-c06f-11eb-9f13-7b807c752036.png)

# Firefox:

![Screen Shot 2021-05-29 at 11 12 00 AM](https://user-images.githubusercontent.com/833719/120080781-48c98000-c06f-11eb-92ea-f2c0925df4bb.png)

![Screen Shot 2021-05-29 at 11 12 08 AM](https://user-images.githubusercontent.com/833719/120080783-49faad00-c06f-11eb-8022-747d3ef54818.png)
