### PR TITLE
Try to remove wounded/uninjured modifiers

### DIFF
--- a/lib/junethack/normalize_death.rb
+++ b/lib/junethack/normalize_death.rb
@@ -16,6 +16,9 @@ class Game
     death = death.gsub /by (an|a) invisible /, "by a "
     death = death.gsub /by invisible /, "by "
 
+    death = death.gsub /uninjured /, ""
+    death = death.gsub /(moderately|critically|seriously|slightly) wounded /, ""
+    
     death = death.gsub(/ (her|his) /, " eir ")
     death = death.gsub(/ (herself|himself) /, " eirself ")
     death = death.gsub(/ (herself|himself)$/, " eirself")

--- a/spec/unittests/normalize_death_spec.rb
+++ b/spec/unittests/normalize_death_spec.rb
@@ -148,7 +148,7 @@ describe Game,"normalization of death strings" do
     end
   end
 
-  it "should substitute everything after chocked on with something" do
+  it "should substitute everything after choked on with something" do
     result = "choked on something"
     @game.death = "choked on the blessed Excalibur"
     @game.normalize_death.should == result
@@ -189,6 +189,17 @@ describe Game,"normalization of death strings" do
     }
   end
 
+  it "normalizes information about wounded/uninjured state" do
+    test = {
+      "killed by a moderately wounded leocrotta" => "killed by a leucrotta",
+      "killed by a uninjured goblin" => "killed by a goblin"
+    }
+    test.each {|message, result|
+      @game.death = message
+      @game.normalize_death.should == result
+    }
+  end
+  
   it "normalizes death messages on every possible starting mount" do
       @game.death = "slipped while mounting a horse"
       expect(@game.normalize_death).to eq "slipped while mounting eir steed"


### PR DESCRIPTION
My next step will be to put in some test cases:
  "killed by a moderately wounded leocrotta" -> "killed by a leucrotta"
  "killed by a uninjured goblin" -> "killed by a goblin"
EDIT: Done.